### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -34,7 +34,7 @@ class syntax_plugin_googlepagerank extends DokuWiki_Syntax_Plugin {
     /**
           * Handle the match
           */
-    function handle($match, $state, $pos, &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
      
             $match = substr($match,11,-2);
             list($url,$width,$method) = explode(',',$match);
@@ -46,7 +46,7 @@ class syntax_plugin_googlepagerank extends DokuWiki_Syntax_Plugin {
     /**
           * Create output
           */
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         if($mode == 'xhtml'){
             if (!preg_match('/^(http:\/\/)?([^\/]+)/i', $data[0])) { $data[0]='http://'.$data[0]; }
             $pr=$this->getpr($data[0]);


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
